### PR TITLE
Expose a Hypermedia API with pagination support.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,85 +1,33 @@
 # API
 
-### Endpoints:
-
-## /api/players
-
-```
-GET /api/players
-```
-
-Returns an array of all player objects, sorted by elo.
-
-```
-{ user_name: String, wins: Number, losses: Number, elo: Number, _id: ObjectId }
-```
-
-Example:
+The Pongbot Hypermedia API provides access to players and challenges. Explore the API from the root.
 
 ```json
-[
-  {
-    "user_name": "foo",
-    "wins": 0,
-    "losses": 0,
-    "elo": 1000,
-    "_id": "53adf57837567d3535d5d5d7",
-    "__v": 0
-  },
-  {
-    "user_name": "bar",
-    "wins": 1,
-    "losses": 0,
-    "elo": 1000,
-    "_id": "53adf7074cf27d7135e4a999",
-    "__v": 0
-  },
-  {
-    "user_name": "baz",
-    "wins": 0,
-    "losses": 0,
-    "elo": 1000,
-    "_id": "53b1afef013005ad444723f6",
-    "__v": 0
+{
+  version: "0.9.0",
+  _links: {
+    self: {
+      href: "http://localhost:3000/"
+    },
+    players: {
+      href: "http://localhost:3000/players"
+    },
+    challenges: {
+      href: "http://localhost:3000/challenges"
+    }
   }
-]
+}
 ```
 
-## /api/challenges
+### Players
 
-```
-GET /api/challenges
-```
+Returns a collection of players.
 
-Returns the last 10 challenges, ordered by date.
+### Challenges
 
-```json
-[
-  {
-    "state": "Accepted",
-    "type": "Single",
-    "date": "2014-06-30T19:51:05.995Z",
-    "_id": "53b1bfa98cbfa893455cf920",
-    "__v": 0,
-    "challenged": [
-      "testbot"
-    ],
-    "challenger": [
-      "vy"
-    ]
-  },
-  {
-    "state": "Accepted",
-    "type": "Single",
-    "date": "2014-06-30T20:02:18.015Z",
-    "_id": "53b1c24acb726ded45be4927",
-    "__v": 0,
-    "challenged": [
-      "test"
-    ],
-    "challenger": [
-      "vy"
-    ]
-  }
-]
-```
+Returns a collection of challenges.
+
+## Pagination
+
+Use `size` to limit the number of items returned and `anchor` to paginate through large collections.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2015/04/25: [#40](https://github.com/andrewvy/slack-pongbot/issues/40) - Expose a Hypermedia API with pagination support - [@dblock](https://github.com/dblock).
 * 2015/04/24: [#55](https://github.com/andrewvy/slack-pongbot/pull/55) - API `matches` became `challenges` and `rankings` became `players` - [@dblock](https://github.com/dblock).
 * 2015/04/22: [#50](https://github.com/andrewvy/slack-pongbot/issues/33) - You can `chicken` out of your own challenge - [@dblock](https://github.com/dblock).
 * 2015/04/22: [#50](https://github.com/andrewvy/slack-pongbot/issues/50) - You can no longer accept or decline your own challenges - [@dblock](https://github.com/dblock).

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,25 +1,76 @@
 var Player = require('../models/Player');
 var Challenge = require('../models/Challenge');
+var pjson = require('../package.json');
+var mongoose = require('mongoose');
+var Q = require('q');
 
 module.exports = {
-  players: function (req, res) {
-    Player.find({}).sort({'elo': 'descending'}).then(
-      function(players) {
-        res.json(players);
+  root: function (req, res) {
+    res.hal({
+      data: {
+        version: pjson.version
       },
-      function(err) {
-        res.status(500).send(err);
+      links: {
+        self: req.rootUrl() + '/',
+        players: req.rootUrl() + '/players',
+        challenges: req.rootUrl() + '/challenges'
+      }
+    });
+  },
+
+  players: function (req, res) {
+    res.halWithPagination(Player, req, res, function(players, req) {
+      return {
+        players: players.map(function(player) {
+          return player.halJSON(req);
+        })
+      };
+    });
+  },
+
+  player: function (req, res) {
+    var promises = [];
+    if (mongoose.Types.ObjectId.isValid(req.params.id)) {
+      promises.push(Player.findById(req.params.id));
+    }
+    promises.push(Player.findOne({ user_name: req.params.id }));
+    Q.any(promises).then(
+      function (player) {
+        if (player && player._id.toString() !== req.params.id) {
+          res.redirect(302, req.rootUrl() + '/players/' + player._id);
+        } else if (player) {
+          res.hal(player.halJSON(req));
+        } else {
+          res.status(404).send('Not Found');
+        }
+      },
+      function (err) {
+        return res.status(500).send(err);
       }
     );
   },
 
   challenges: function (req, res) {
-    Challenge.find({}).sort({'date': 'desc'}).then(
-      function(challenges) {
-        res.json(challenges);
+    res.halWithPagination(Challenge, req, res, function(challenges, req) {
+      return {
+        challenges: challenges.map(function(challenge) {
+          return challenge.halJSON(req);
+        })
+      };
+    });
+  },
+
+  challenge: function (req, res) {
+    Challenge.findById(req.params.id).then(
+      function (challenge) {
+        if (challenge) {
+          res.hal(challenge.halJSON(req));
+        } else {
+          res.status(404).send('Not Found');
+        }
       },
-      function(err) {
-        res.status(500).send(err);
+      function (err) {
+        return res.status(500).send(err);
       }
     );
   }

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var hal = require("express-hal");
 var bodyParser = require('body-parser');
 var request = require('request');
 
@@ -11,20 +12,19 @@ var Challenge = require('../models/Challenge');
 
 module.exports.instance = function () {
   var app = express();
-  app.use(bodyParser.urlencoded({extended: false}));
+  app.use(bodyParser.urlencoded({ extended: false }));
   app.use(bodyParser.json());
+  app.use(hal.middleware);
 
-  // Pongbot Routes
+  app.use(require('./url').middleware);
+  app.use(require('./hal').middleware);
 
-  app.get('/', function (req, res) {
-    res.send('pong');
-  });
-
+  app.get('/', api_routes.root);
   app.post('/', pong_routes.index);
-
-  // Pongbot API Routes
-  app.get('/api/players', api_routes.players);
-  app.get('/api/challenges', api_routes.challenges);
+  app.get('/players', api_routes.players);
+  app.get('/players/:id', api_routes.player);
+  app.get('/challenges', api_routes.challenges);
+  app.get('/challenges/:id', api_routes.challenge);
 
   return app;
 };

--- a/lib/hal.js
+++ b/lib/hal.js
@@ -1,0 +1,19 @@
+module.exports.middleware = function(req, res, next) {
+  res.halWithPagination = function (model, req, res, embeds) {
+    var size = req.query.size || 10;
+    model.findPaginated({}, null, { sort: { _id: 'ascending' }}, function (err, result) {
+      if (err) return res.status(500).send(err);
+      res.hal({
+        data: {
+          totalPages: result.totalPages
+        },
+        embeds: embeds(result.documents, req),
+        links: {
+          self: req.fullPath() + '?size=' + size + (req.query.anchor ? '&anchor=' + req.query.anchor : ''),
+          next: result.nextAnchorId ? req.fullPath() + '?size=' + size + '&anchor=' + result.nextAnchorId : null
+        }
+      });
+    }, size, req.query.anchor);
+  };
+  return next();
+};

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,0 +1,11 @@
+module.exports.middleware = function(req, res, next) {
+  req.rootUrl = function() {
+    var port = req.app.settings.port;
+    res.locals.requested_url = req.protocol + '://' + req.hostname  + (port == 80 || port == 443 ? '' : ':' + port);
+    return req.protocol + "://" + req.get('host');
+  };
+  req.fullPath = function() {
+    return req.rootUrl() + req.path;
+  };
+  return next();
+};

--- a/models/Challenge.js
+++ b/models/Challenge.js
@@ -1,4 +1,5 @@
 var mongoose = require('mongoose');
+var mongoosePages = require('mongoose-pages');
 var Schema = mongoose.Schema;
 
 var ChallengeSchema = new Schema({
@@ -9,6 +10,28 @@ var ChallengeSchema = new Schema({
 	challenged: Array
 });
 
-var Challenge = mongoose.model('Challenge', ChallengeSchema);
+mongoosePages.anchor(ChallengeSchema);
 
+ChallengeSchema.methods = {
+  halJSON: function (req) {
+    return {
+      data: {
+        type: this.type,
+        state: this.state,
+        date: this.date
+      },
+      links: {
+        self: req.rootUrl() + '/challenges/' + this._id,
+        challengers: this.challenger.map(function(player) {
+          return { href: req.rootUrl() + '/players/' + player };
+        }),
+        challenged: this.challenged.map(function(player) {
+          return { href: req.rootUrl() + '/players/' + player };
+        })
+      }
+    };
+  }
+};
+
+var Challenge = mongoose.model('Challenge', ChallengeSchema);
 module.exports = Challenge;

--- a/models/Player.js
+++ b/models/Player.js
@@ -1,4 +1,5 @@
 var mongoose = require('mongoose');
+var mongoosePages = require('mongoose-pages');
 var Schema = mongoose.Schema;
 
 var PlayerSchema = new Schema({
@@ -10,6 +11,23 @@ var PlayerSchema = new Schema({
 	currentChallenge: { type: Schema.Types.ObjectId, ref: 'Challenge' }
 });
 
-var Player = mongoose.model('Player', PlayerSchema);
+mongoosePages.anchor(PlayerSchema);
 
+PlayerSchema.methods = {
+  halJSON: function (req) {
+    return {
+      data: {
+        user_name: this.user_name,
+        wins: this.wins,
+        losses: this.losses,
+        elo: this.elo
+      },
+      links: {
+        self: req.rootUrl() + '/players/' + this._id,
+      }
+    };
+  }
+};
+
+var Player = mongoose.model('Player', PlayerSchema);
 module.exports = Player;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,82 +4,82 @@
   "dependencies": {
     "body-parser": {
       "version": "1.12.3",
-      "from": "body-parser@*",
-      "resolved": "http://registry.npmjs.org/body-parser/-/body-parser-1.12.3.tgz",
+      "from": "body-parser@",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.3.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
           "from": "bytes@1.0.0",
-          "resolved": "http://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
-          "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "from": "content-type@~1.0.1",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "debug": {
           "version": "2.1.3",
-          "from": "debug@>=2.1.3 <2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "from": "debug@~2.1.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.0",
               "from": "ms@0.7.0",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "from": "depd@~1.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "iconv-lite": {
           "version": "0.4.8",
           "from": "iconv-lite@0.4.8",
-          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
         },
         "on-finished": {
           "version": "2.2.0",
-          "from": "on-finished@>=2.2.0 <2.3.0",
-          "resolved": "http://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+          "from": "on-finished@~2.2.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
               "from": "ee-first@1.1.0",
-              "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "qs": {
           "version": "2.4.1",
           "from": "qs@2.4.1",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
         },
         "raw-body": {
           "version": "1.3.4",
           "from": "raw-body@1.3.4",
-          "resolved": "http://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz"
         },
         "type-is": {
           "version": "1.6.1",
-          "from": "type-is@>=1.6.1 <1.7.0",
-          "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+          "from": "type-is@~1.6.1",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.0.10",
-              "from": "mime-types@>=2.0.1 <2.1.0",
-              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "from": "mime-types@~2.0.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "from": "mime-db@~1.8.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             }
@@ -89,202 +89,202 @@
     },
     "express": {
       "version": "4.12.3",
-      "from": "express@>=4.10.6 <5.0.0",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.12.3.tgz",
+      "from": "express@^4.10.6",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.12.3.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.5",
-          "from": "accepts@>=1.2.5 <1.3.0",
-          "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
+          "from": "accepts@~1.2.5",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.0.10",
-              "from": "mime-types@>=2.0.10 <2.1.0",
-              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "from": "mime-types@~2.0.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "from": "mime-db@~1.8.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.1",
               "from": "negotiator@0.5.1",
-              "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
             }
           }
         },
         "content-disposition": {
           "version": "0.5.0",
           "from": "content-disposition@0.5.0",
-          "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
-          "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "from": "content-type@~1.0.1",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "cookie": {
           "version": "0.1.2",
           "from": "cookie@0.1.2",
-          "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
           "from": "cookie-signature@1.0.6",
-          "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.1.3",
-          "from": "debug@>=2.1.3 <2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "from": "debug@~2.1.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.0",
               "from": "ms@0.7.0",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "from": "depd@~1.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
           "from": "escape-html@1.0.1",
-          "resolved": "http://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
           "version": "1.5.1",
-          "from": "etag@>=1.5.1 <1.6.0",
-          "resolved": "http://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+          "from": "etag@~1.5.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
           "dependencies": {
             "crc": {
               "version": "3.2.1",
               "from": "crc@3.2.1",
-              "resolved": "http://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
             }
           }
         },
         "finalhandler": {
           "version": "0.3.4",
           "from": "finalhandler@0.3.4",
-          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
         },
         "fresh": {
           "version": "0.2.4",
           "from": "fresh@0.2.4",
-          "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.0",
           "from": "merge-descriptors@1.0.0",
-          "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
         },
         "methods": {
           "version": "1.1.1",
-          "from": "methods@>=1.1.1 <1.2.0",
-          "resolved": "http://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+          "from": "methods@~1.1.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
         },
         "on-finished": {
           "version": "2.2.0",
-          "from": "on-finished@>=2.2.0 <2.3.0",
-          "resolved": "http://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+          "from": "on-finished@~2.2.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
               "from": "ee-first@1.1.0",
-              "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "parseurl@>=1.3.0 <1.4.0",
+          "from": "parseurl@~1.3.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.3",
           "from": "path-to-regexp@0.1.3",
-          "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
           "version": "1.0.7",
-          "from": "proxy-addr@>=1.0.7 <1.1.0",
-          "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz",
+          "from": "proxy-addr@~1.0.7",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
+              "from": "forwarded@~0.1.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "0.1.9",
               "from": "ipaddr.js@0.1.9",
-              "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
             }
           }
         },
         "qs": {
           "version": "2.4.1",
           "from": "qs@2.4.1",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
-          "from": "range-parser@>=1.0.2 <1.1.0",
+          "from": "range-parser@~1.0.2",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
           "version": "0.12.2",
           "from": "send@0.12.2",
-          "resolved": "http://registry.npmjs.org/send/-/send-0.12.2.tgz",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.12.2.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
               "from": "destroy@1.0.3",
-              "resolved": "http://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
             },
             "mime": {
               "version": "1.3.4",
               "from": "mime@1.3.4",
-              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.0",
               "from": "ms@0.7.0",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.9.2",
-          "from": "serve-static@>=1.9.2 <1.10.0",
-          "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
+          "from": "serve-static@~1.9.2",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
         },
         "type-is": {
           "version": "1.6.1",
-          "from": "type-is@>=1.6.1 <1.7.0",
-          "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+          "from": "type-is@~1.6.1",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.0.10",
-              "from": "mime-types@>=2.0.10 <2.1.0",
-              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "from": "mime-types@~2.0.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.8.0",
-                  "from": "mime-db@>=1.8.0 <1.9.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "from": "mime-db@~1.8.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                 }
               }
             }
@@ -292,74 +292,86 @@
         },
         "vary": {
           "version": "1.0.0",
-          "from": "vary@>=1.0.0 <1.1.0",
+          "from": "vary@~1.0.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
         },
         "utils-merge": {
           "version": "1.0.0",
           "from": "utils-merge@1.0.0",
-          "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        }
+      }
+    },
+    "express-hal": {
+      "version": "0.0.1",
+      "from": "express-hal@",
+      "resolved": "https://registry.npmjs.org/express-hal/-/express-hal-0.0.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "0.8.2",
+          "from": "lodash@~0.8.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.8.2.tgz"
         }
       }
     },
     "mongoose": {
       "version": "4.0.1",
-      "from": "mongoose@*",
-      "resolved": "http://registry.npmjs.org/mongoose/-/mongoose-4.0.1.tgz",
+      "from": "mongoose@",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.0.1.tgz",
       "dependencies": {
         "hooks-fixed": {
           "version": "1.0.1",
           "from": "hooks-fixed@1.0.1",
-          "resolved": "http://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.0.1.tgz"
         },
         "mongodb": {
           "version": "2.0.24",
           "from": "mongodb@2.0.24",
-          "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.0.24.tgz",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.24.tgz",
           "dependencies": {
             "mongodb-core": {
               "version": "1.1.20",
               "from": "mongodb-core@1.1.20",
-              "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-1.1.20.tgz",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.1.20.tgz",
               "dependencies": {
                 "bson": {
                   "version": "0.2.21",
-                  "from": "bson@>=0.2.0 <0.3.0",
-                  "resolved": "http://registry.npmjs.org/bson/-/bson-0.2.21.tgz",
+                  "from": "bson@~0.2",
+                  "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.21.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "1.7.0",
                       "from": "nan@1.7.0",
-                      "resolved": "http://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.5.0",
                   "from": "mkdirp@0.5.0",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
-                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.2.6",
                   "from": "rimraf@2.2.6",
-                  "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
                 },
                 "kerberos": {
                   "version": "0.0.10",
-                  "from": "kerberos@>=0.0.0 <0.1.0",
-                  "resolved": "http://registry.npmjs.org/kerberos/-/kerberos-0.0.10.tgz",
+                  "from": "kerberos@~0.0",
+                  "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.10.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "1.7.0",
                       "from": "nan@1.7.0",
-                      "resolved": "http://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
                     }
                   }
                 }
@@ -368,26 +380,25 @@
             "readable-stream": {
               "version": "1.0.31",
               "from": "readable-stream@1.0.31",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -396,104 +407,108 @@
         },
         "ms": {
           "version": "0.1.0",
-          "from": "ms@0.1.0",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.1.0.tgz"
+          "from": "ms@0.1.0"
         },
         "sliced": {
           "version": "0.0.5",
           "from": "sliced@0.0.5",
-          "resolved": "http://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
         },
         "muri": {
           "version": "1.0.0",
           "from": "muri@1.0.0",
-          "resolved": "http://registry.npmjs.org/muri/-/muri-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz"
         },
         "mpromise": {
           "version": "0.5.4",
           "from": "mpromise@0.5.4",
-          "resolved": "http://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz"
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz"
         },
         "mpath": {
           "version": "0.1.1",
           "from": "mpath@0.1.1",
-          "resolved": "http://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
         },
         "kareem": {
           "version": "1.0.0",
           "from": "kareem@1.0.0",
-          "resolved": "http://registry.npmjs.org/kareem/-/kareem-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.0.tgz"
         },
         "regexp-clone": {
           "version": "0.0.1",
           "from": "regexp-clone@0.0.1",
-          "resolved": "http://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
         },
         "mquery": {
           "version": "1.4.0",
           "from": "mquery@1.4.0",
-          "resolved": "http://registry.npmjs.org/mquery/-/mquery-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.4.0.tgz",
           "dependencies": {
             "bluebird": {
               "version": "2.3.2",
               "from": "bluebird@2.3.2",
-              "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.3.2.tgz"
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.3.2.tgz"
             },
             "debug": {
               "version": "0.7.4",
               "from": "debug@0.7.4",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         },
         "async": {
           "version": "0.9.0",
           "from": "async@0.9.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         }
       }
     },
+    "mongoose-pages": {
+      "version": "0.0.3",
+      "from": "mongoose-pages@",
+      "resolved": "https://registry.npmjs.org/mongoose-pages/-/mongoose-pages-0.0.3.tgz"
+    },
     "node-slack": {
       "version": "0.0.5",
-      "from": "node-slack@>=0.0.5 <0.0.6",
-      "resolved": "http://registry.npmjs.org/node-slack/-/node-slack-0.0.5.tgz",
+      "from": "node-slack@^0.0.5",
+      "resolved": "https://registry.npmjs.org/node-slack/-/node-slack-0.0.5.tgz",
       "dependencies": {
         "deferred": {
           "version": "0.7.1",
           "from": "deferred@0.7.1",
-          "resolved": "http://registry.npmjs.org/deferred/-/deferred-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/deferred/-/deferred-0.7.1.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.10.6",
-              "from": "es5-ext@>=0.10.2 <0.11.0",
-              "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+              "from": "es5-ext@~0.10.2",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
               "dependencies": {
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.3 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                  "from": "es6-iterator@~0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                  "from": "es6-symbol@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "event-emitter": {
               "version": "0.3.3",
-              "from": "event-emitter@>=0.3.1 <0.4.0",
-              "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+              "from": "event-emitter@~0.3.1",
+              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
             },
             "d": {
               "version": "0.1.1",
-              "from": "d@>=0.1.1 <0.2.0",
-              "resolved": "http://registry.npmjs.org/d/-/d-0.1.1.tgz"
+              "from": "d@~0.1.1",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
             },
             "next-tick": {
               "version": "0.2.2",
-              "from": "next-tick@>=0.2.2 <0.3.0",
-              "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+              "from": "next-tick@~0.2.2",
+              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
             }
           }
         }
@@ -501,47 +516,47 @@
     },
     "pluralize": {
       "version": "1.1.2",
-      "from": "pluralize@*",
-      "resolved": "http://registry.npmjs.org/pluralize/-/pluralize-1.1.2.tgz"
+      "from": "pluralize@",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.1.2.tgz"
     },
     "q": {
       "version": "1.2.0",
-      "from": "q@*",
-      "resolved": "http://registry.npmjs.org/q/-/q-1.2.0.tgz"
+      "from": "q@",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.2.0.tgz"
     },
     "request": {
       "version": "2.55.0",
-      "from": "request@*",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.55.0.tgz",
+      "from": "request@",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
       "dependencies": {
         "bl": {
           "version": "0.9.4",
-          "from": "bl@>=0.9.0 <0.10.0",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+          "from": "bl@~0.9.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.26 <1.1.0",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@~1.0.26",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -550,255 +565,250 @@
         },
         "caseless": {
           "version": "0.9.0",
-          "from": "caseless@>=0.9.0 <0.10.0",
-          "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+          "from": "caseless@~0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.0 <0.7.0",
-          "resolved": "http://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+          "from": "forever-agent@~0.6.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "from": "form-data@~0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz"
+              "from": "async@~0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-          "resolved": "http://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+          "from": "json-stringify-safe@~5.0.0"
         },
         "mime-types": {
           "version": "2.0.10",
-          "from": "mime-types@>=2.0.1 <2.1.0",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+          "from": "mime-types@~2.0.10",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.8.0",
-              "from": "mime-db@>=1.8.0 <1.9.0",
-              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+              "from": "mime-db@~1.8.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
-          "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+          "from": "node-uuid@~1.4.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "qs": {
           "version": "2.4.1",
-          "from": "qs@2.4.1",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "from": "qs@~2.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
-          "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+          "from": "tunnel-agent@~0.4.0"
         },
         "tough-cookie": {
           "version": "0.12.1",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
               "from": "punycode@>=0.2.0",
-              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             }
           }
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "from": "http-signature@~0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
-              "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+              "from": "assert-plus@^0.1.5",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
             },
             "asn1": {
               "version": "0.1.11",
               "from": "asn1@0.1.11",
-              "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
               "from": "ctype@0.5.3",
-              "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.6.0",
-          "from": "oauth-sign@>=0.6.0 <0.7.0",
-          "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+          "from": "oauth-sign@~0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
         },
         "hawk": {
           "version": "2.3.1",
-          "from": "hawk@>=2.3.0 <2.4.0",
-          "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "from": "hawk@~2.3.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.12.0",
-              "from": "hoek@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
+              "from": "hoek@2.x.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.12.0.tgz"
             },
             "boom": {
               "version": "2.7.1",
-              "from": "boom@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+              "from": "boom@2.x.x",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.4",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+              "from": "cryptiles@2.x.x",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+              "from": "sntp@1.x.x",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+          "from": "aws-sign2@~0.5.0"
         },
         "stringstream": {
           "version": "0.0.4",
-          "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "http://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+          "from": "stringstream@~0.0.4"
         },
         "combined-stream": {
           "version": "0.0.7",
-          "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "from": "combined-stream@~0.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "0.0.5",
               "from": "delayed-stream@0.0.5",
-              "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
             }
           }
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.1 <0.2.0",
-          "resolved": "http://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+          "from": "isstream@~0.1.1",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "har-validator": {
           "version": "1.6.1",
-          "from": "har-validator@>=1.4.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
+          "from": "har-validator@^1.4.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
           "dependencies": {
             "bluebird": {
               "version": "2.9.24",
-              "from": "bluebird@>=2.9.21 <3.0.0",
-              "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+              "from": "bluebird@^2.9.21",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
             },
             "chalk": {
               "version": "1.0.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.0.1",
-                  "from": "ansi-styles@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "has-ansi@>=1.0.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "supports-color@>=1.3.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.8.0",
-              "from": "commander@>=2.7.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.0.tgz",
+              "from": "commander@^2.7.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                  "from": "graceful-readlink@>= 1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.10.1",
-              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
+              "from": "is-my-json-valid@^2.10.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                  "from": "generate-function@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.1.1",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
+                  "from": "generate-object-property@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "1.1.0",
-                  "from": "jsonpointer@>=1.1.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                  "from": "jsonpointer@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                  "from": "xtend@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "app.js",
   "dependencies": {
     "express": "^4.10.6",
+    "express-hal": "",
     "node-slack": "^0.0.5",
     "body-parser": "",
     "mongoose": "",
+    "mongoose-pages": "",
     "request": "",
     "pluralize": "",
     "q": ""

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -1,4 +1,5 @@
 var chai = require('chai');
+chai.use(require('chai-string'));
 var expect = chai.expect;
 var app = require('../lib/app').instance();
 var pong = require('../lib/pong');
@@ -7,11 +8,33 @@ var request = require('supertest');
 describe('Routes', function () {
   require('./shared').setup();
 
+  describe('root', function () {
+    it('returns links', function (done) {
+      request(app)
+        .get('/')
+        .expect(200)
+        .end(function(err, res) {
+          if (err) throw err;
+          expect(res.body._links.self.href).to.endsWith('/');
+          expect(res.body._links.players.href).to.endsWith('/players');
+          expect(res.body._links.challenges.href).to.endsWith('/challenges');
+          done();
+        });
+    });
+  });
+
   describe('challenges', function() {
     describe('with a challenge', function () {
+      var playerWangHoe = null;
+      var playerZhangJike = null;
+      var challengeBetweenWangHoeAndZhangJike = null;
+
       beforeEach(function (done) {
-        pong.registerPlayers(['WangHao', 'ZhangJike']).then(function () {
-          pong.createSingleChallenge('WangHao', 'ZhangJike').then(function () {
+        pong.registerPlayers(['WangHao', 'ZhangJike']).then().spread(function (p1, p2) {
+          playerWangHoe = p1;
+          playerZhangJike = p2;
+          pong.createSingleChallenge('WangHao', 'ZhangJike').then(function (result) {
+            challengeBetweenWangHoeAndZhangJike = result.challenge;
             done();
           });
         });
@@ -19,17 +42,32 @@ describe('Routes', function () {
 
       it('returns challenges', function (done) {
         request(app)
-          .get('/api/challenges')
+          .get('/challenges')
           .expect(200)
           .end(function(err, res) {
             if (err) throw err;
-            var challenges = res.body;
+            var challenges = res.body._embedded.challenges;
             expect(challenges.length).to.eq(1);
             var challenge = challenges[0];
             expect(challenge.state).to.eq('Proposed');
             expect(challenge.type).to.eq('Singles');
-            expect(challenge.challenger).to.eql(['WangHao']);
-            expect(challenge.challenged).to.eql(['ZhangJike']);
+            expect(challenge._links.challengers[0].href).to.endsWith('/players/WangHao');
+            expect(challenge._links.challenged[0].href).to.endsWith('/players/ZhangJike');
+            done();
+          });
+      });
+
+      it('returns a challenge by id', function (done) {
+        request(app)
+          .get('/challenges/' + challengeBetweenWangHoeAndZhangJike._id)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) throw err;
+            var challenge = res.body;
+            expect(challenge.state).to.eq('Proposed');
+            expect(challenge.type).to.eq('Singles');
+            expect(challenge._links.challengers[0].href).to.endsWith('/players/WangHao');
+            expect(challenge._links.challenged[0].href).to.endsWith('/players/ZhangJike');
             done();
           });
       });
@@ -37,23 +75,107 @@ describe('Routes', function () {
   });
 
   describe('players', function() {
-    describe('with a player', function () {
+    describe('with 3 players', function () {
+      var playerZhangJike = null;
+      var playerDengYaping = null;
+      var playerChenQi = null;
       beforeEach(function (done) {
-        pong.registerPlayer('WangHao').then(function () {
+        pong.registerPlayers(['ZhangJike', 'DengYaping', 'ChenQi']).then().spread(function (p1, p2, p3) {
+          playerZhangJike = p1;
+          playerDengYaping = p2;
+          playerWangHoe = p3;
+          done();
+        });
+      });
+
+      it('paginates players on page 1', function (done) {
+        request(app)
+          .get('/players?size=1')
+          .expect(200)
+          .end(function(err, res) {
+            if (err) throw err;
+            var players = res.body._embedded.players;
+            expect(players.length).to.eq(1);
+            var player = players[0];
+            expect(player.user_name).to.eq('ZhangJike');
+            expect(res.body._links.next.href).to.endsWith('/players?size=1&anchor=' + playerZhangJike._id);
+            done();
+          });
+      });
+
+      it('paginates players on page 2', function (done) {
+        request(app)
+          .get('/players?size=1&anchor=' + playerZhangJike._id)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) throw err;
+            var players = res.body._embedded.players;
+            expect(players.length).to.eq(1);
+            var player = players[0];
+            expect(player.user_name).to.eq('DengYaping');
+            expect(res.body._links.next.href).to.endsWith('/players?size=1&anchor=' + playerDengYaping._id);
+            done();
+          });
+      });
+
+      it('paginates players on page 3', function (done) {
+        request(app)
+          .get('/players?size=1&anchor=' + playerDengYaping._id)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) throw err;
+            var players = res.body._embedded.players;
+            expect(players.length).to.eq(1);
+            var player = players[0];
+            expect(player.user_name).to.eq('ChenQi');
+            expect(res.body._links.next.href).to.be.null;
+            done();
+          });
+      });
+    });
+
+    describe('with a player', function () {
+      var playerWangHoe = null;
+      beforeEach(function (done) {
+        pong.registerPlayer('WangHao').then(function (player) {
+          playerWangHoe = player;
           done();
         });
       });
 
       it('returns players', function (done) {
         request(app)
-          .get('/api/players')
+          .get('/players')
           .expect(200)
           .end(function(err, res) {
             if (err) throw err;
-            var players = res.body;
+            var players = res.body._embedded.players;
             expect(players.length).to.eq(1);
             var player = players[0];
             expect(player.user_name).to.eq('WangHao');
+            done();
+          });
+      });
+
+      it('returns a player by id', function (done) {
+        request(app)
+          .get('/players/' + playerWangHoe._id)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) throw err;
+            var player = res.body;
+            expect(player.user_name).to.eq('WangHao');
+            done();
+          });
+      });
+
+      it('redirects to a player by name', function (done) {
+        request(app)
+          .get('/players/WangHao')
+          .expect(302)
+          .end(function(err, res) {
+            if (err) throw err;
+            expect(res.headers.location).to.endsWith('/players/' + playerWangHoe._id);
             done();
           });
       });


### PR DESCRIPTION
This addresses #40, rewriting the API to be a Hypermedia HAL API, with support for pagination and linking between items.

* You can hit the root of the service to get the version of slack-pongbot and links to players and challenges.
* You can get a single player or challenge or collections of those.
* You can paginate through large collections simply by following links.
* You can use generic clients, like [traverson](https://www.npmjs.com/package/traverson-hal) in JS or [hyperclient](https://github.com/codegram/hyperclient) to talk to the API, no specialized client required.

If you're interested in why Hypermedia/HAL, check out http://artsy.github.io/blog/2014/09/12/designing-the-public-artsy-api/. The nicest thing is that if you have a JSONView extension in Chrome for example, you can just click through the API!