### PR TITLE
Support @player.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2015/04/26: [#37](https://github.com/andrewvy/slack-pongbot/issues/37) - Support @player - [@dblock](https://github.com/dblock).
 * 2015/04/25: [#40](https://github.com/andrewvy/slack-pongbot/issues/40) - Expose a Hypermedia API with pagination support - [@dblock](https://github.com/dblock).
 * 2015/04/24: [#55](https://github.com/andrewvy/slack-pongbot/pull/55) - API `matches` became `challenges` and `rankings` became `players` - [@dblock](https://github.com/dblock).
 * 2015/04/22: [#50](https://github.com/andrewvy/slack-pongbot/issues/33) - You can `chicken` out of your own challenge - [@dblock](https://github.com/dblock).

--- a/lib/app.js
+++ b/lib/app.js
@@ -18,6 +18,7 @@ module.exports.instance = function () {
 
   app.use(require('./url').middleware);
   app.use(require('./hal').middleware);
+  app.use(require('./player_middleware').middleware);
 
   app.get('/', api_routes.root);
   app.post('/', pong_routes.index);

--- a/lib/player_middleware.js
+++ b/lib/player_middleware.js
@@ -1,0 +1,43 @@
+var Player = require('../models/Player');
+var Challenge = require('../models/Challenge');
+var pong = require('./pong');
+var Q = require('q');
+
+// a middlware that keeps player IDs and names in sync
+module.exports.middleware = function(req, res, next) {
+  var hook = req.body;
+  if (hook && hook.user_name && hook.user_id) {
+    Player.where({
+      '$or' : [
+        { user_name: hook.user_name },
+        { user_id: hook.user_id }
+      ]}).findOne().then(
+        function (player) {
+          if (player && ((player.user_id !== hook.user_id) || (player.user_name !== hook.user_name))) {
+
+            if (process.env.LOG_LEVEL === 'debug') {
+              console.log("Updating player '" + player.user_name + "' (" + player.user_id + ').');
+            }
+
+            player.user_id = hook.user_id;
+            player.user_name = hook.user_name;
+            player.save().then(
+              function () {
+                return next();
+              },
+              function (err) {
+                return next();
+              }
+            );
+          } else {
+            return next();
+          }
+        },
+        function (err) {
+          return next();
+        }
+      );
+  } else {
+    return next();
+  }
+};

--- a/lib/pong.js
+++ b/lib/pong.js
@@ -29,8 +29,13 @@ var pong = {
   },
 
   findPlayer: function (player_name) {
-    return Player.where({ user_name: player_name })
-      .findOne()
+    var q = null;
+    if (player_name[0] === '<' && player_name[1] === '@' && player_name[player_name.length - 1] === '>') {
+      q = { user_id: player_name.substr(2, player_name.length - 3) };
+    } else {
+      q = { user_name: player_name };
+    }
+    return Player.where(q).findOne()
       .then(function (player) {
         var deferred = Q.defer();
         if (player) {
@@ -84,25 +89,28 @@ var pong = {
   },
 
   ensureUniquePlayers: function(players, cb) {
-    var playerCounts = players.reduce(function (acc, curr) {
-      if (typeof acc[curr] == 'undefined') {
-        acc[curr] = 1;
-      } else {
-        acc[curr] += 1;
-      }
-      return acc;
-    }, {});
+    return pong.findPlayers(players).then(function(players) {
+      var playerCounts = players.reduce(function (acc, curr) {
+        curr = curr.user_name;
+        if (typeof acc[curr] == 'undefined') {
+          acc[curr] = 1;
+        } else {
+          acc[curr] += 1;
+        }
+        return acc;
+      }, {});
 
-    return Q.all(Object.keys(playerCounts).map(function (key) {
-      var deferred = Q.defer();
-      var count = playerCounts[key];
-      if (count > 1) {
-        deferred.reject(new Error('Does ' + key + ' have ' + 2 * count + ' hands?'));
-      } else {
-        deferred.resolve(key);
-      }
-      return deferred.promise;
-    }));
+      return Q.all(Object.keys(playerCounts).map(function (key) {
+        var deferred = Q.defer();
+        var count = playerCounts[key];
+        if (count > 1) {
+          deferred.reject(new Error('Does ' + key + ' have ' + 2 * count + ' hands?'));
+        } else {
+          deferred.resolve(key);
+        }
+        return deferred.promise;
+      }));
+    });
   },
 
   createSingleChallenge: function (c1, c2) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,6 +1,7 @@
 var Player = require('../models/Player');
 var Challenge = require('../models/Challenge');
 var pong = require('./pong');
+var Q = require('q');
 
 module.exports.index = function (req, res) {
   var hook = req.body;
@@ -19,12 +20,17 @@ module.exports.index = function (req, res) {
       if (params.length != 2) {
         res.json({ text: "Invalid params, use 'pongbot register'." });
       } else {
-        pong.findPlayer(hook.user_name).then(
+        var promises = [];
+        promises.push(pong.findPlayer(hook.user_name));
+        if (hook.user_id) {
+          promises.push(pong.findPlayer('<@' + hook.user_id + '>'));
+        }
+        Q.any(promises).then(
           function (player) {
             res.json({ text: "You've already registered!" });
           },
           function (err) {
-            pong.registerPlayer(hook.user_name).then(function (player) {
+            pong.registerPlayer(hook.user_name, { user_id: hook.user_id }).then(function (player) {
               res.json({ text: 'Successfully registered! Welcome to the system, ' + hook.user_name + '.' });
             }, function (err) {
               res.json({ text: err.toString() });

--- a/models/Player.js
+++ b/models/Player.js
@@ -3,12 +3,13 @@ var mongoosePages = require('mongoose-pages');
 var Schema = mongoose.Schema;
 
 var PlayerSchema = new Schema({
-	user_name: { type: String, index: { unique: true }, required: true },
-	wins: Number,
-	losses: Number,
-	elo: Number,
-	tau: Number,
-	currentChallenge: { type: Schema.Types.ObjectId, ref: 'Challenge' }
+  user_id: String,
+  user_name: { type: String, index: { unique: true }, required: true },
+  wins: Number,
+  losses: Number,
+  elo: Number,
+  tau: Number,
+  currentChallenge: { type: Schema.Types.ObjectId, ref: 'Challenge' }
 });
 
 mongoosePages.anchor(PlayerSchema);
@@ -17,6 +18,7 @@ PlayerSchema.methods = {
   halJSON: function (req) {
     return {
       data: {
+        user_id: this.user_id,
         user_name: this.user_name,
         wins: this.wins,
         losses: this.losses,

--- a/test/player_middleware_tests.js
+++ b/test/player_middleware_tests.js
@@ -1,0 +1,78 @@
+var chai = require('chai');
+chai.use(require('chai-string'));
+var expect = chai.expect;
+var pong = require('../lib/pong');
+var Player = require('../models/Player');
+var Challenge = require('../models/Challenge');
+var sinon = require('sinon');
+
+var request = require('supertest');
+var routes = require('../lib/routes');
+var app = require('../lib/app').instance();
+
+describe('Player Middleware', function () {
+  require('./shared').setup();
+
+  describe('with a pre-registered player with username', function () {
+    beforeEach(function (done) {
+      pong.registerPlayer('WangHao').then(function() {
+        done();
+      });
+    });
+
+    it('automatically updates ID', function (done) {
+      request(app)
+        .post('/')
+        .send({ text: 'pongbot foobar', user_id: 'U02BEFY4U', user_name: 'WangHao' })
+        .expect(200)
+        .end(function(err, res){
+          if (err) throw err;
+          pong.findPlayer('<@U02BEFY4U>').then(function (player) {
+            expect(player.user_id).to.eq('U02BEFY4U');
+            expect(player.user_name).to.eq('WangHao');
+            done();
+          });
+        });
+    });
+
+    it('does not update with a different ID', function (done) {
+      request(app)
+        .post('/')
+        .send({ text: 'pongbot foobar', user_id: 'ZZZZZZZZ', user_name: 'NotWangHao' })
+        .expect(200)
+        .end(function(err, res){
+          if (err) throw err;
+          pong.findPlayer('WangHao').then(function (player) {
+            expect(player.user_id).to.be.undefined;
+            expect(player.user_name).to.eq('WangHao');
+            done();
+          });
+        });
+    });
+  });
+
+  describe('with a pre-registered player with username and ID', function () {
+    beforeEach(function (done) {
+      pong.registerPlayer('WangHao', { user_id: 'U02BEFY4U' }).then(function() {
+        done();
+      });
+    });
+
+    it('automatically keeps name in sync', function (done) {
+      request(app)
+        .post('/')
+        .send({ text: 'pongbot foobar', user_id: 'U02BEFY4U', user_name: 'WangHaoWasRenamed' })
+        .expect(200)
+        .end(function(err, res){
+          if (err) throw err;
+          pong.findPlayer('<@U02BEFY4U>').then(function (player) {
+            expect(player.user_id).to.eq('U02BEFY4U');
+            expect(player.user_name).to.eq('WangHaoWasRenamed');
+            done();
+          });
+        });
+    });
+  });
+});
+
+

--- a/test/pong_tests.js
+++ b/test/pong_tests.js
@@ -40,14 +40,24 @@ describe('Pong', function () {
   describe('#findPlayer', function () {
     describe('with a player', function () {
       beforeEach(function (done) {
-        pong.registerPlayer('ZhangJike').then(function () {
+        pong.registerPlayer('ZhangJike', { user_id: 'U02BEFY4U' }).then(function () {
           done();
         });
       });
 
-      it('finds a player', function (done) {
+      it('finds a player by name', function (done) {
         pong.findPlayer('ZhangJike').then(function (player) {
           expect(player).not.to.be.null;
+          expect(player.user_id).to.eq('U02BEFY4U');
+          expect(player.user_name).to.eq('ZhangJike');
+          done();
+        });
+      });
+
+      it('finds a player by ID', function (done) {
+        pong.findPlayer('<@U02BEFY4U>').then(function (player) {
+          expect(player).not.to.be.null;
+          expect(player.user_id).to.eq('U02BEFY4U');
           expect(player.user_name).to.eq('ZhangJike');
           done();
         });
@@ -313,6 +323,12 @@ describe('Pong', function () {
   });
 
   describe('ensureUniquePlayers', function () {
+    beforeEach(function (done) {
+      pong.registerPlayers(['ZhangJike', 'DengYaping', 'ChenQi', 'ViktorBarna']).then(function () {
+        done();
+      });
+    });
+
     it('fails with a duplicate', function (done) {
       pong.ensureUniquePlayers(['ZhangJike', 'ZhangJike', 'ZhangJike', 'ChenQi']).then(undefined, function (err) {
         expect(err).to.not.be.null;
@@ -328,7 +344,6 @@ describe('Pong', function () {
       });
     });
   });
-
 
   describe('createSingleChallenge', function () {
     it('returns an error when the challenger cannot be found', function (done) {

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -39,15 +39,26 @@ describe('Routes', function () {
 
     describe('with a pre-registered player', function () {
       beforeEach(function (done) {
-        pong.registerPlayer('WangHao').then(function() {
+        pong.registerPlayer('WangHao', { user_id: 'U02BEFY4U' }).then(function() {
           done();
         });
       });
 
-      it('does not register twice', function (done) {
+      it('does not register twice by name', function (done) {
         request(app)
           .post('/')
           .send({ text: 'pongbot register', user_name: 'WangHao' })
+          .expect(200)
+          .end(function(err, res) {
+            expect(res.body.text).to.eq("You've already registered!");
+            done();
+          });
+      });
+
+      it('does not register twice by ID', function (done) {
+        request(app)
+          .post('/')
+          .send({ text: 'pongbot register', user_name: 'WangHaoWasRenamed', user_id: 'U02BEFY4U' })
           .expect(200)
           .end(function(err, res) {
             expect(res.body.text).to.eq("You've already registered!");


### PR DESCRIPTION
I think this works for supporting @player.

* A middleware that updates player records that don't have ID whenever a player makes a pongbot call. Incidentally this also supports renaming of the player automagically, except it doesn't update existing challenges (when we transition challenger's and challenged into using IDs that will solve it).
* Looking up 'player' or '<@USER_ID>' which is how slack seems to send things to us.
* Ensuring unique names when making challenges takes either 'player' or '<@USER_ID>' and using names for creating challenges.

Closes #37.