### PR TITLE
More chicken-y chicken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2015/06/25: [#66](https://github.com/andrewvy/slack-pongbot/pull/66) - Any player can `chicken` out of an accepted challenge - [@101100](https://github.com/101100).
 * 2015/04/27: [#64](https://github.com/andrewvy/slack-pongbot/issues/64) - Fix: challenge created even when another challenge already exists - [@dblock](https://github.com/dblock).
 * 2015/04/26: [#54](https://github.com/andrewvy/slack-pongbot/issues/54) - Leaderboard Infinity is now case-insensitive - [@dblock](https://github.com/dblock).
 * 2015/04/26: [#56](https://github.com/andrewvy/slack-pongbot/issues/56) - Usernames are now case-insensitive - [@dblock](https://github.com/dblock).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,15 @@ git checkout -b my-feature-branch
 
 ## Bundle Install and Test
 
-Ensure that you can build the project and run tests.
+Ensure that you can build the project and run tests and linter.
 
 ```
 npm install
 npm test
+npm run lint
 ```
+
+**Note**: You will need a copy of [MongoDB](https://www.mongodb.org/downloads) running on `localhost` in order to run the tests.
 
 ## Write Tests
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pongbot lost
 # Other Commands
 
 * `pongbot decline` - Decline's any proposed match.
-* `pongbot chicken` - Chicken out of your own challenge.
+* `pongbot chicken` - Chicken out of your own challenge before it is accepted, or out of an accepted challenge (as the challenger or challenged).
 * `pongbot leaderboard <1-infinity>` - Shows the top players, sorted by Elo.
 * `pongbot rank <someone's name>` - Gets that person's stats. If none given, it will return your own stats.
 * `pongbot source` - Get's Pongbot's Github repository.

--- a/lib/pong.js
+++ b/lib/pong.js
@@ -227,6 +227,17 @@ var pong = {
           } else {
             deferred.reject(new Error('Only ' + challenge.challenger[0] + ' can do that.'));
           }
+        } else if (challenge && challenge.state == 'Accepted') {
+            challenge.state = 'Chickened';
+            Q.when(challenge.save(), function (challenge) {
+              Player.update({ currentChallenge: challenge._id }, { currentChallenge: null }, { multi: true }).then(function () {
+                if (player_name == challenge.challenger[0] || player_name == challenge.challenger[1]) {
+                  deferred.resolve({ message: player_name + ' chickened out of the challenge against ' + challenge.challenged.join(' and ') + ".", challenge: challenge });
+                } else {
+                  deferred.resolve({ message: player_name + ' chickened out of the challenge against ' + challenge.challenger.join(' and ') + ".", challenge: challenge });
+                }
+              });
+            });
         } else {
           deferred.reject(new Error("First, challenge someone!"));
         }

--- a/test/pong_tests.js
+++ b/test/pong_tests.js
@@ -657,6 +657,30 @@ describe('Pong', function () {
           done();
         });
       });
+
+      describe('after it is accepted', function () {
+        beforeEach(function (done) {
+          pong.acceptChallenge('DengYaping').then(function (result) {
+            done();
+          });
+        });
+
+        it('chickens out of the challenge for the challenger', function (done) {
+          pong.chickenChallenge('ZhangJike').then(function (result) {
+            expect(result.message).to.eq("ZhangJike chickened out of the challenge against DengYaping.");
+            expect(result.challenge.state).to.eq('Chickened');
+            done();
+          });
+        });
+
+        it('chickens out of the challenge for the challenged', function (done) {
+          pong.chickenChallenge('DengYaping').then(function (result) {
+            expect(result.message).to.eq("DengYaping chickened out of the challenge against ZhangJike.");
+            expect(result.challenge.state).to.eq('Chickened');
+            done();
+          });
+        });
+      });
     });
 
     describe('with a doubles challenge', function () {
@@ -676,24 +700,64 @@ describe('Pong', function () {
         });
       });
 
-      it("can't chiceck out of the the challenge with player two", function (done) {
+      it("can't chicken out of the the challenge with player two", function (done) {
         pong.chickenChallenge('DengYaping').then(undefined, function (err) {
           expect(err.message).to.eq('Only ZhangJike can do that.');
           done();
         });
       });
 
-      it("can't chiceck out of the the challenge with player three", function (done) {
+      it("can't chicken out of the the challenge with player three", function (done) {
         pong.chickenChallenge('ChenQi').then(undefined, function (err) {
           expect(err.message).to.eq('Only ZhangJike can do that.');
           done();
         });
       });
 
-      it("can't chiceck out of the the challenge with player four", function (done) {
+      it("can't chicken out of the the challenge with player four", function (done) {
         pong.chickenChallenge('ViktorBarna').then(undefined, function (err) {
           expect(err.message).to.eq('Only ZhangJike can do that.');
           done();
+        });
+      });
+
+      describe('after it is accepted', function () {
+        beforeEach(function (done) {
+          pong.acceptChallenge('ChenQi').then(function (result) {
+            done();
+          });
+        });
+
+        it('chickens out of the challenge for the challenger', function (done) {
+          pong.chickenChallenge('ZhangJike').then(function (result) {
+            expect(result.message).to.eq("ZhangJike chickened out of the challenge against ChenQi and ViktorBarna.");
+            expect(result.challenge.state).to.eq('Chickened');
+            done();
+          });
+        });
+
+        it('chickens out of the challenge for player two', function (done) {
+          pong.chickenChallenge('DengYaping').then(function (result) {
+            expect(result.message).to.eq("DengYaping chickened out of the challenge against ChenQi and ViktorBarna.");
+            expect(result.challenge.state).to.eq('Chickened');
+            done();
+          });
+        });
+
+        it('chickens out of the challenge for player three', function (done) {
+          pong.chickenChallenge('ChenQi').then(function (result) {
+            expect(result.message).to.eq("ChenQi chickened out of the challenge against ZhangJike and DengYaping.");
+            expect(result.challenge.state).to.eq('Chickened');
+            done();
+          });
+        });
+
+        it('chickens out of the challenge for player four', function (done) {
+          pong.chickenChallenge('ViktorBarna').then(function (result) {
+            expect(result.message).to.eq("ViktorBarna chickened out of the challenge against ZhangJike and DengYaping.");
+            expect(result.challenge.state).to.eq('Chickened');
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
I've added the ability for any member of a challenge to chicken out of a challenge after it has been accepted.  This is behaviour that would have been useful at my workplace at least once and seemed straight-forward to implement.

I implemented tests and the new behaviour and updated the documentation.  The code passes the linter, but I was *not* able to run the unit tests on either my Windows or Linux machine.  In both cases the tests fail with the error `Error: connect ECONNREFUSED`.  I beleive that this might be due to needing a server set up to test against.  If so, can you describe the steps necessary to do this so I can run the tests locally?