### PR TITLE
Enhancement + Leaderboard page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,12 +29,12 @@
           <td>ELO</td>
         </tr>
         <tr ng-repeat="player in leaderboard">
-          <td>{{ player.rank }}</td>
-          <td><b>{{ player.name.substring(0, player.name.length - 1);  }}</b></td>
-          <td><b>{{ player.wins + player.loss }}</b></td>
+          <td>{{ ($index + 1) }}</td>
+          <td><b>{{ player.user_name  }}</b></td>
+          <td><b>{{ player.wins + player.losses }}</b></td>
           <td>{{ player.wins }}</td>
-          <td>{{ player.loss }}</td>
-          <td>{{ player.elo.substring(0, player.elo.length - 1);  }}</td>
+          <td>{{ player.losses }}</td>
+          <td>{{ player.elo  }}</td>
         </tr>
       </table>
 
@@ -95,23 +95,9 @@
       angular.module('pong', []);
       angular.module('pong')
       .controller('PongCtrl', function($scope, $http) {
-        $http.post('/', { text: 'pongbot leaderboard' })
+        $http.get('/leaderboard')
         .success(function(data) {
-          if (data.text === '') {
-            return;
-          }
-          $scope.leaderboard = data.text.split('\n');
-          angular.forEach($scope.leaderboard, function(player, index) {
-            var attributes = player.split(' ');
-            $scope.leaderboard[index] = {
-              rank: attributes[0],
-              name: attributes[1],
-              wins: parseInt(attributes[2]),
-              loss: parseInt(attributes[4]),
-              elo:  attributes[7]
-            };
-          });
-          $scope.leaderboard.pop();
+          $scope.leaderboard = data._embedded.players;
         });
       });
     </script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,119 @@
+<html lang="en" ng-app="pong">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <title>Ping Pong Leaderboard</title>
+
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+  </head>
+
+  <body>
+    <div class="container" ng-controller="PongCtrl">
+      <div class="page-header text-center">
+        <h1>Ping Pong</h1>
+      </div>
+
+      <h2>Leaderboard</h2>
+      <p class="lead" ng-if="!leaderboard">No one has registered yet!</p>
+      <table class="table table-striped table-bordered" ng-show="leaderboard">
+        <tr>
+          <td>Rank</td>
+          <td>Player Name</td>
+          <td>Games Played</td>
+          <td>Wins</td>
+          <td>Loss</td>
+          <td>ELO</td>
+        </tr>
+        <tr ng-repeat="player in leaderboard">
+          <td>{{ player.rank }}</td>
+          <td><b>{{ player.name.substring(0, player.name.length - 1);  }}</b></td>
+          <td><b>{{ player.wins + player.loss }}</b></td>
+          <td>{{ player.wins }}</td>
+          <td>{{ player.loss }}</td>
+          <td>{{ player.elo.substring(0, player.elo.length - 1);  }}</td>
+        </tr>
+      </table>
+
+      <h2>How to participate?</h2>
+      <div class="panel panel-default">
+        <div class="panel-heading"><b>Register first!</b></div>
+        <div class="panel-body">
+          Go to your ping-pong Slack channel and type <code>pongbot register</code>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">Challenge someone!</div>
+        <div class="panel-body">
+          <code>pongbot (challenge|vs) "player"</code>or
+          <br>
+          <code>pongbot (challenge|vs) doubles "teammate's name" (against|vs) "opponent_1" "opponent_2"</code>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">Accept or decline the challenge...</div>
+        <div class="panel-body">
+          <code>pongbot (ok|accept)</code>
+          <br>
+          <code>pongbot (no|decline)</code>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">Results?</div>
+        <div class="panel-body">
+          Only the loser can finish a game by typongbot <code>pongbot lost</code>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">See who is leading!</div>
+        <div class="panel-body">
+          <code>pongbot leaderboard</code>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">What else?</div>
+        <div class="panel-body">
+          <code>pongbot chicken</code> Chicken out of your own challenge before it is accepted, or out of an accepted challenge (as the challenger or challenged).
+          <br>
+          <code>pongbot rank "playername"</code> Gets that person's stats. If none given, it will return your own stats.</code>
+        </div>
+      </div>
+    </div>
+
+    <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.1/angular.min.js"></script>
+    <script type="text/javascript">
+      angular.module('pong', []);
+      angular.module('pong')
+      .controller('PongCtrl', function($scope, $http) {
+        $http.post('/', { text: 'pongbot leaderboard' })
+        .success(function(data) {
+          if (data.text === '') {
+            return;
+          }
+          $scope.leaderboard = data.text.split('\n');
+          angular.forEach($scope.leaderboard, function(player, index) {
+            var attributes = player.split(' ');
+            $scope.leaderboard[index] = {
+              rank: attributes[0],
+              name: attributes[1],
+              wins: parseInt(attributes[2]),
+              loss: parseInt(attributes[4]),
+              elo:  attributes[7]
+            };
+          });
+          $scope.leaderboard.pop();
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,7 +13,8 @@ module.exports = {
       links: {
         self: req.rootUrl() + '/',
         players: req.rootUrl() + '/players',
-        challenges: req.rootUrl() + '/challenges'
+        challenges: req.rootUrl() + '/challenges',
+        leaderboard: req.rootUrl() + '/leaderboard',
       }
     });
   },
@@ -25,6 +26,35 @@ module.exports = {
           return player.halJSON(req);
         })
       };
+    });
+  },
+
+  leaderboard: function (req, res) {
+    Player.find({
+      "$or" : [
+        { 'wins' : { '$ne' : 0 } },
+        { 'losses' : { '$ne' : 0 }
+      }]
+    })
+    .sort({ 'elo' : 'descending', 'wins' : 'descending' })
+    .find()
+    .then(function (players) {
+      res.hal({
+        data: {
+          totalPages: 1
+        },
+        embeds: {
+          players: players.map(function(player) {
+            return player.halJSON(req);
+          }),
+        },
+        links: {
+          self: req.fullPath(),
+        }
+      });
+    },
+    function (err) {
+      res.json({ text: "Error: " + err.message });
     });
   },
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,13 +20,16 @@ module.exports.instance = function () {
   app.use(require('./hal').middleware);
   app.use(require('./player_middleware').middleware);
 
-  app.get('/', api_routes.root);
   app.post('/', pong_routes.index);
+
+  app.get('/', api_routes.root);
   app.get('/players', api_routes.players);
   app.get('/players/:id', api_routes.player);
   app.get('/challenges', api_routes.challenges);
   app.get('/challenges/:id', api_routes.challenge);
-  app.get('/leaderboard', pong_routes.indexPage);
+  app.get('/leaderboard', api_routes.leaderboard);
+
+  app.get('/info', pong_routes.leaderboard);
 
 
   return app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -26,6 +26,8 @@ module.exports.instance = function () {
   app.get('/players/:id', api_routes.player);
   app.get('/challenges', api_routes.challenges);
   app.get('/challenges/:id', api_routes.challenge);
+  app.get('/leaderboard', pong_routes.indexPage);
+
 
   return app;
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,12 @@ var Challenge = require('../models/Challenge');
 var pong = require('./pong');
 var Q = require('q');
 var _ = require('underscore');
+var path = require('path');
+
+
+module.exports.indexPage = function (req, res) {
+  res.sendFile(path.join(__dirname + '/../index.html'));
+}
 
 module.exports.index = function (req, res) {
   var hook = req.body;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -8,7 +8,7 @@ var path = require('path');
 
 module.exports.indexPage = function (req, res) {
   res.sendFile(path.join(__dirname + '/../index.html'));
-}
+};
 
 module.exports.index = function (req, res) {
   var hook = req.body;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -6,7 +6,7 @@ var _ = require('underscore');
 var path = require('path');
 
 
-module.exports.indexPage = function (req, res) {
+module.exports.leaderboard = function (req, res) {
   res.sendFile(path.join(__dirname + '/../index.html'));
 };
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -41,10 +41,11 @@ module.exports.index = function (req, res) {
       }
       break;
 
+    case 'vs':
     case 'challenge':
       pong.findPlayer(hook.user_name).then(
         function (player) {
-          if ((params[2] == 'double' || params[2] == 'doubles') && (params[4] == 'against') && (params.length == 7)) {
+          if ((params[2] == 'double' || params[2] == 'doubles') && (params[4] == 'against' || params[4] == 'vs') && (params.length == 7)) {
             return pong.createDoubleChallenge(hook.user_name, params[3], params[5], params[6]).then(
               function (result) {
                 return pong.getDuelGif().then(function (url) {
@@ -66,6 +67,17 @@ module.exports.index = function (req, res) {
                 return res.json({ text: err.toString() });
               }
             );
+          } else if (params.length == 3) {
+            return pong.createSingleChallenge(hook.user_name, params[2]).then(
+              function (result) {
+                return pong.getDuelGif().then(function (url) {
+                  res.json({ text: result.message + ' ' + url });
+                });
+              },
+              function (err) {
+                return res.json({ text: err.toString() });
+              }
+            );
           } else {
             res.json({ text: "Invalid params, use _pongbot challenge <singles|doubles> <opponent|teammate> against <opponent> <opponent>_." });
           }
@@ -76,6 +88,7 @@ module.exports.index = function (req, res) {
       );
       break;
 
+    case 'ok':
     case 'accept':
       if (params.length != 2) {
         res.json({ text: "Invalid params, use _pongbot accept_." });
@@ -91,6 +104,7 @@ module.exports.index = function (req, res) {
       }
       break;
 
+    case 'no':
     case 'decline':
       if (params.length != 2) {
         res.json({ text: "Invalid params, use _pongbot decline_." });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -181,4 +181,54 @@ describe('Routes', function () {
       });
     });
   });
+
+  describe('leaderboard', function () {
+    describe('with 3 players', function () {
+      beforeEach(function (done) {
+        pong.registerPlayers(['ZhangJike', 'DengYaping', 'ChenQi']).then().spread(function (p1, p2, p3) {
+          done();
+        });
+      });
+
+      describe('without challenge', function () {
+        it('returns no player', function (done) {
+          request(app)
+            .get('/leaderboard')
+            .expect(200)
+            .end(function(err, res) {
+              if (err) throw err;
+              var players = res.body._embedded.players;
+              expect(players.length).to.eq(0);
+              done();
+            });
+        });
+      });
+
+      describe('with 1 challenge', function () {
+        beforeEach(function (done) {
+          pong.createSingleChallenge('ZhangJike', 'DengYaping').then(function () {
+            pong.acceptChallenge('DengYaping').then(function () {
+              pong.lose('DengYaping').then(function () {
+                done();
+              });
+            });
+          });
+        });
+
+        it('returns 2 players', function (done) {
+          request(app)
+            .get('/leaderboard')
+            .expect(200)
+            .end(function(err, res) {
+              if (err) throw err;
+              var players = res.body._embedded.players;
+              expect(players.length).to.eq(2);
+              var player = players[0];
+              expect(player.user_name).to.eq('ZhangJike');
+              done();
+            });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Thanks for the awesome work on this bot!

Here are some small improvements that we are using + a leaderboard page and some doc for non technical people.

Commands improvements:
- [x] Respond to a challenge with `pongbot ok` `pongbot no`
- [x] Challenge someone on singles with `pongbot <challenge|vs> jonathan` (no need for the word `single(s)`)

Leaderboard page:
- [x] New API `/leaderboard` endpoint 
- [x] Tests
- [x] Accessible via `/info`
  <img width="1788" alt="screen shot 2015-07-06 at 7 14 04 pm" src="https://cloud.githubusercontent.com/assets/710923/8537398/41e51fe6-2413-11e5-8613-e5f5a0184ced.png">
